### PR TITLE
Added id in buildProfileForm attributes

### DIFF
--- a/LoginRegister.module
+++ b/LoginRegister.module
@@ -848,7 +848,7 @@ class LoginRegister extends WireData implements Module, ConfigurableModule {
 			$inputfield = $user->getInputfield($field); 
 			if(!$inputfield) continue;
 			if($fieldName == 'email') $inputfield->attr('required', 'required');
-			$inputfield->attr('name', 'profile_' . $inputfield->attr('name'));
+			$inputfield->attr('id+name', 'profile_' . $inputfield->attr('name'));
 			$form->add($inputfield);
 		}
 		


### PR DESCRIPTION
After hooking a checkbox field render (to conform to a bootstrap v4.3x checkbox component), I was wondering why it was working for the Register form but not the Profile form.

I then noticed the difference between them in their respective build*Form methods:

`$inputfield->attr('name', 'profile_' . $inputfield->attr('name'));`
vs
`$inputfield->attr('id+name', 'register_' . $inputfield->attr('name'));`

Kindly add the id+ in the Profile buildProfileForm. I'm sure it was just an unintended omission.

Thanks much.